### PR TITLE
Add Flutter appointment booking demo

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/auth_provider.dart';
+import 'providers/appointment_provider.dart';
+import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
 
 void main() {
   runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => AppointmentProvider()),
+      ],
+      child: MaterialApp(
+        title: 'Appointment Booking',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: Consumer<AuthProvider>(
+          builder: (context, auth, _) =>
+              auth.isLoggedIn ? const HomeScreen() : const LoginScreen(),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -1,0 +1,7 @@
+class Appointment {
+  final String id;
+  String service;
+  DateTime dateTime;
+
+  Appointment({required this.id, required this.service, required this.dateTime});
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,7 @@
+class User {
+  final String username;
+  final String password;
+  String name;
+
+  User({required this.username, required this.password, required this.name});
+}

--- a/lib/providers/appointment_provider.dart
+++ b/lib/providers/appointment_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/appointment.dart';
+
+class AppointmentProvider extends ChangeNotifier {
+  final List<Appointment> _appointments = [];
+
+  List<Appointment> get appointments => List.unmodifiable(_appointments);
+
+  void addAppointment(String service, DateTime dateTime) {
+    final appointment = Appointment(
+      id: const Uuid().v4(),
+      service: service,
+      dateTime: dateTime,
+    );
+    _appointments.add(appointment);
+    notifyListeners();
+  }
+
+  void updateAppointment(Appointment appointment, String service, DateTime dateTime) {
+    final index = _appointments.indexWhere((a) => a.id == appointment.id);
+    if (index != -1) {
+      _appointments[index].service = service;
+      _appointments[index].dateTime = dateTime;
+      notifyListeners();
+    }
+  }
+
+  void removeAppointment(Appointment appointment) {
+    _appointments.removeWhere((a) => a.id == appointment.id);
+    notifyListeners();
+  }
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../models/user.dart';
+
+class AuthProvider extends ChangeNotifier {
+  final List<User> _registeredUsers = [];
+  User? _currentUser;
+
+  User? get currentUser => _currentUser;
+  bool get isLoggedIn => _currentUser != null;
+
+  void register(String username, String password, String name) {
+    _registeredUsers.add(User(username: username, password: password, name: name));
+    notifyListeners();
+  }
+
+  bool login(String username, String password) {
+    try {
+      final user = _registeredUsers.firstWhere(
+        (u) => u.username == username && u.password == password,
+      );
+      _currentUser = user;
+      notifyListeners();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void logout() {
+    _currentUser = null;
+    notifyListeners();
+  }
+}

--- a/lib/screens/appointment_form_screen.dart
+++ b/lib/screens/appointment_form_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/appointment_provider.dart';
+import '../models/appointment.dart';
+
+class AppointmentFormScreen extends StatefulWidget {
+  final Appointment? appointment;
+  const AppointmentFormScreen({super.key, this.appointment});
+
+  @override
+  State<AppointmentFormScreen> createState() => _AppointmentFormScreenState();
+}
+
+class _AppointmentFormScreenState extends State<AppointmentFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _serviceController = TextEditingController();
+  DateTime _selectedDate = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.appointment != null) {
+      _serviceController.text = widget.appointment!.service;
+      _selectedDate = widget.appointment!.dateTime;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.appointment == null ? 'New Appointment' : 'Edit Appointment'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _serviceController,
+                decoration: const InputDecoration(labelText: 'Service'),
+                validator: (value) => value!.isEmpty ? 'Enter service' : null,
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text('Date: ${_selectedDate.toLocal()}'.split(' ')[0]),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      final date = await showDatePicker(
+                        context: context,
+                        initialDate: _selectedDate,
+                        firstDate: DateTime.now(),
+                        lastDate: DateTime.now().add(const Duration(days: 365)),
+                      );
+                      if (date != null) {
+                        setState(() => _selectedDate = date);
+                      }
+                    },
+                    child: const Text('Select Date'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    if (widget.appointment == null) {
+                      context.read<AppointmentProvider>().addAppointment(
+                            _serviceController.text,
+                            _selectedDate,
+                          );
+                    } else {
+                      context.read<AppointmentProvider>().updateAppointment(
+                            widget.appointment!,
+                            _serviceController.text,
+                            _selectedDate,
+                          );
+                    }
+                    Navigator.of(context).pop();
+                  }
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+import '../providers/appointment_provider.dart';
+import '../models/appointment.dart';
+import 'appointment_form_screen.dart';
+import 'profile_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appointments = context.watch<AppointmentProvider>().appointments;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Appointments'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.person),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const ProfileScreen()),
+            ),
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: appointments.length,
+        itemBuilder: (context, index) {
+          final appointment = appointments[index];
+          return ListTile(
+            title: Text(appointment.service),
+            subtitle: Text(appointment.dateTime.toString()),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => AppointmentFormScreen(appointment: appointment),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: () {
+                    context.read<AppointmentProvider>().removeAppointment(appointment);
+                  },
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const AppointmentFormScreen()),
+        ),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+import 'register_screen.dart';
+import 'home_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  String _error = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _usernameController,
+                decoration: const InputDecoration(labelText: 'Username'),
+                validator: (value) => value!.isEmpty ? 'Enter username' : null,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (value) => value!.isEmpty ? 'Enter password' : null,
+              ),
+              const SizedBox(height: 16),
+              if (_error.isNotEmpty) Text(_error, style: const TextStyle(color: Colors.red)),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    final success = context.read<AuthProvider>().login(
+                          _usernameController.text,
+                          _passwordController.text,
+                        );
+                    if (!success) {
+                      setState(() => _error = 'Invalid credentials');
+                    } else {
+                      Navigator.of(context).pushReplacement(
+                        MaterialPageRoute(builder: (_) => const HomeScreen()),
+                      );
+                    }
+                  }
+                },
+                child: const Text('Login'),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const RegisterScreen()),
+                  );
+                },
+                child: const Text('Create Account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthProvider>();
+    final user = auth.currentUser!;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Username: ${user.username}'),
+            Text('Name: ${user.name}'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                auth.logout();
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              },
+              child: const Text('Logout'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _nameController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _usernameController,
+                decoration: const InputDecoration(labelText: 'Username'),
+                validator: (value) => value!.isEmpty ? 'Enter username' : null,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (value) => value!.isEmpty ? 'Enter password' : null,
+              ),
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (value) => value!.isEmpty ? 'Enter your name' : null,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    context.read<AuthProvider>().register(
+                          _usernameController.text,
+                          _passwordController.text,
+                          _nameController.text,
+                        );
+                    Navigator.of(context).pop();
+                  }
+                },
+                child: const Text('Register'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.0.5
+  uuid: ^4.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create Appointment and User models
- add AuthProvider and AppointmentProvider for managing state
- implement screens for login, registration, profile, home and appointment form
- update `pubspec.yaml` with provider and uuid dependencies
- set up `main.dart` with MultiProvider

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684750e5ea9c8321afd1daff045fe065